### PR TITLE
switch to swallow v0.1 / faiss 1.11.0

### DIFF
--- a/workspace-nim-with-rag/jupyter_notebook/gke_handson_requirements.txt
+++ b/workspace-nim-with-rag/jupyter_notebook/gke_handson_requirements.txt
@@ -28,7 +28,7 @@ defusedxml==0.7.1
 dill==0.3.8
 docstring_parser==0.16
 executing==2.1.0
-faiss-cpu==1.8.0.post1
+faiss-cpu==1.11.0
 fastjsonschema==2.20.0
 filelock==3.15.4
 fqdn==1.5.1

--- a/workspace-nim-with-rag/k8s-manifest/swallow.yaml
+++ b/workspace-nim-with-rag/k8s-manifest/swallow.yaml
@@ -24,7 +24,7 @@ spec:
         - |
           apk add git-lfs && \
           git lfs install && \
-          git clone https://huggingface.co/tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.3 /models && \
+          git clone https://huggingface.co/tokyotech-llm/Llama-3.1-Swallow-8B-Instruct-v0.1 /models && \
           cd /models && \
           git lfs pull
         volumeMounts:


### PR DESCRIPTION
For GKE workshop, versions of following 1 library and 1 model are modified.

- model
 - llama 3.1 swallow 8b instruct: v0.3  to v0.1 
- library
 - faiss-cpu: 1.8.0.post1 to 1.11.0  